### PR TITLE
Adds tox.ini and basic rock sanity tests

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -18,6 +18,12 @@ jobs:
       rockcraft-revisions: '{"amd64": "1783", "arm64": "1784"}'
       arch-skipping-maximize-build-space: '["arm64"]'
       platform-labels: '{"arm64": ["self-hosted", "Linux", "ARM64", "jammy", "large"]}'
+  run-tests:
+    uses: canonical/k8s-workflows/.github/workflows/run_tests.yaml@feat/multi-version-tests
+    needs: [build-and-push-arch-specifics]
+    secrets: inherit
+    with:
+      rock-metas: ${{ needs.build-and-push-arch-specifics.outputs.rock-metas }}
   scan-images:
     uses: canonical/k8s-workflows/.github/workflows/scan_images.yaml@main
     needs: [build-and-push-arch-specifics]

--- a/tests/.copyright.tmpl
+++ b/tests/.copyright.tmpl
@@ -1,0 +1,1 @@
+Copyright ${years} ${owner}.

--- a/tests/requirements-dev.txt
+++ b/tests/requirements-dev.txt
@@ -1,0 +1,5 @@
+black==24.3.0
+codespell==2.2.4
+flake8==6.0.0
+isort==5.12.0
+licenseheaders==0.8.8

--- a/tests/requirements-test.txt
+++ b/tests/requirements-test.txt
@@ -1,0 +1,5 @@
+coverage[toml]==7.2.5
+pytest==7.3.1
+PyYAML==6.0.1
+tenacity==8.2.3
+git+https://github.com/canonical/k8s-test-harness.git@main

--- a/tests/sanity/test_kubectl.py
+++ b/tests/sanity/test_kubectl.py
@@ -1,0 +1,20 @@
+#
+# Copyright 2024 Canonical, Ltd.
+#
+
+import os
+
+from k8s_test_harness.util import docker_util
+
+
+def test_kubectl_rock():
+    """Test kubectl rock."""
+
+    image_variable = "ROCK_KUBECTL_1_30_2"
+    image = os.getenv(image_variable)
+    assert image is not None, f"${image_variable} is not set"
+
+    # check binary name and version.
+    process = docker_util.run_in_docker(image, False, "kubectl", "version")
+
+    assert "Client Version: v1.30" in process.stdout

--- a/tests/sanity/test_velero.py
+++ b/tests/sanity/test_velero.py
@@ -1,0 +1,29 @@
+#
+# Copyright 2024 Canonical, Ltd.
+#
+
+import os
+
+from k8s_test_harness.util import docker_util
+
+
+def test_velero_rock():
+    """Test Velero rock."""
+
+    image_variable = "ROCK_VELERO_1_13_2"
+    image = os.getenv(image_variable)
+    assert image is not None, f"${image_variable} is not set"
+
+    # check binary name and version.
+    process = docker_util.run_in_docker(image, False, "/velero", "version")
+    expected_err = "error finding Kubernetes API server config in --kubeconfig"
+    assert expected_err in process.stderr
+
+    # check helper binary.
+    process = docker_util.run_in_docker(image, False, "/velero-helper")
+    expected_err = "at least one argument must be provided, the working mode"
+    assert expected_err in process.stderr
+
+    # check restic and its version.
+    process = docker_util.run_in_docker(image, True, "restic", "version")
+    assert "restic" in process.stdout and "0.15.0" in process.stdout

--- a/tests/tox.ini
+++ b/tests/tox.ini
@@ -1,0 +1,68 @@
+# Copyright 2024 Canonical Ltd.
+
+[tox]
+no_package = True
+skip_missing_interpreters = True
+envlist = format, lint, sanity, integration
+min_version = 4.0.0
+
+[testenv]
+setenv =
+    PYTHONBREAKPOINT=pdb.set_trace
+    PY_COLORS=1
+pass_env =
+    PYTHONPATH
+
+[testenv:format]
+description = Apply coding style standards to code
+deps = -r {tox_root}/requirements-dev.txt
+commands =
+    licenseheaders -t {tox_root}/.copyright.tmpl -cy -o 'Canonical, Ltd' -d {tox_root}/sanity
+    licenseheaders -t {tox_root}/.copyright.tmpl -cy -o 'Canonical, Ltd' -d {tox_root}/integration
+    isort {tox_root}/sanity {tox_root}/integration --profile=black
+    black {tox_root}/sanity {tox_root}/integration
+
+[testenv:lint]
+description = Check code against coding style standards
+deps = -r {tox_root}/requirements-dev.txt
+commands =
+    codespell {tox_root}/sanity {tox_root}/integration
+    flake8 {tox_root}/sanity {tox_root}/integration
+    licenseheaders -t {tox_root}/.copyright.tmpl -cy -o 'Canonical, Ltd' -d {tox_root}/sanity --dry
+    licenseheaders -t {tox_root}/.copyright.tmpl -cy -o 'Canonical, Ltd' -d {tox_root}/integration --dry
+    isort {tox_root}/sanity {tox_root}/integration --profile=black --check
+    black {tox_root}/sanity {tox_root}/integration --check --diff
+
+[testenv:sanity]
+description = Run sanity tests
+passenv = *
+deps = -r {tox_root}/requirements-test.txt
+commands =
+    pytest -v \
+        --maxfail 1 \
+        --tb native \
+        --log-cli-level DEBUG \
+        --disable-warnings \
+        {posargs} \
+        {tox_root}/sanity
+pass_env =
+    TEST_*
+    ROCK_*
+
+[testenv:integration]
+description = Run integration tests
+deps = -r {tox_root}/requirements-test.txt
+commands =
+    echo "WARNING: This is a placeholder test - no test is implemented here."
+pass_env =
+    TEST_*
+    ROCK_*
+
+[flake8]
+max-line-length = 120
+select = E,W,F,C,N
+# E231: missing whitespace after ':'
+# E231 excluded for false positives in strings and fstrings.
+ignore = W503,E231
+exclude = venv,.git,.tox,.tox_env,.venv,build,dist,*.egg_info
+show-source = true


### PR DESCRIPTION
Adds the following tox targets: format, lint, sanity, integration.

Adds basic rock tests, checking that the expected files exist in the rock, and checking the added executables outputs.

Note that Pebble was recently updated, no longer allowing exec after ``--verbose`` (which is in the entrypoint). Using the ``--entrypoint`` docker run parameter instead.

Depends-On: https://github.com/canonical/k8s-test-harness/pull/11