### PR TITLE
Remove runner size label

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -17,7 +17,7 @@ jobs:
       # pinning to use rockcraft 1.3.0 feature `entrypoint-service`
       rockcraft-revisions: '{"amd64": "1783", "arm64": "1784"}'
       arch-skipping-maximize-build-space: '["arm64"]'
-      platform-labels: '{"arm64": ["self-hosted", "Linux", "ARM64", "jammy", "large"]}'
+      platform-labels: '{"arm64": ["self-hosted", "Linux", "ARM64", "jammy"]}'
   run-tests:
     uses: canonical/k8s-workflows/.github/workflows/run_tests.yaml@feat/multi-version-tests
     needs: [build-and-push-arch-specifics]


### PR DESCRIPTION
There is a shortage on ``large`` arm runners. Let's just take any available runner.